### PR TITLE
Change brake torque to 700Nm for Carla Vehicle

### DIFF
--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -62,7 +62,7 @@ class Controller(object):
         
         if linear_vel == 0. and current_vel < 0.1:
             throttle = 0
-            brake = 400 # N*m - to hold the car in place if we are stopped at a light. Acceleration - 1m/s^2
+            brake = 700 # N*m - to hold the car in place if we are stopped at a light. Acceleration - 1m/s^2
         elif throttle < 0.1 and vel_error < 0:
             throttle = 0
             decel = max(vel_error, self.decel_limit)


### PR DESCRIPTION
As mentioned in the notes of the walkthrough the brake torque should be 700Nm so that it also works with the Carla vehicle.

> In the walkthrough, only 400 Nm of torque is applied to hold the vehicle stationary. This turns out to be slightly less than the amount of force needed, and Carla will roll forward with only 400Nm of torque. To prevent Carla from moving you should apply approximately 700 Nm of torque.