### PR TITLE
Updated rospy.logwarn and disabled image classification if necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,7 @@ To set up port forwarding, please refer to the [instructions from term 2](https:
 
 ### Usage
 
-1. Clone the project repository
-```bash
-git clone https://github.com/xiaohuieddie/CarND-Capstone.git
-```
+1. `git clone` this project repository
 
 2. Install python dependencies
 ```bash

--- a/ros/src/tl_detector/light_classification/tl_classifier.py
+++ b/ros/src/tl_detector/light_classification/tl_classifier.py
@@ -71,24 +71,25 @@ class TLClassifier(object):
         scores = np.squeeze(scores)
         classes = np.squeeze(classes)
 
-        count_NonRed = count_red = 0
+        count = {1: 0, 2: 0, 3: 0}  # 1 - Red, 2 - Yellow, 3 - Green
         for i in range(len(boxes)):
             if scores[i] > min_score_thresh:  
                 light_state = self.classes[classes[i]]
                 if light_state == TrafficLight.RED:
-                    count_red += 1
-                else:
-                    count_NonRed += 1
-
-        rospy.logwarn("red: %s, not red: %s", count_red, count_NonRed)
-        # if the number of red traffic light is larger than the one of non-red lights, return RED state
-        if count_red < count_NonRed:
-            return TrafficLight.GREEN
-        elif count_red != 0:
-            rospy.logwarn("RED Traffic Light detected by the model!")
-            return TrafficLight.RED
-        else:       
-            return TrafficLight.UNKNOWN
+                    count[1] += 1
+                elif light_state == TrafficLight.YELLOW:
+                    count[2] += 1
+                elif light_state == TrafficLight.GREEN:
+                    count[3] += 1
+                    
+                    
+        count_list = sorted(count.items(), key = lambda kv:(kv[1], kv[0])) # sort the count dictionary and then return the biggest one
+        rospy.logwarn("Number of Red: %s, Number of Yellow: %s, Number of Green: %s", count[1], count[2], count[3])
+        if count_list[-1][1] != 0:
+            return self.classes[count_list[-1][0]]
+        else:
+            return TrafficLight.UNKNOWN   # return UNKNOWN if not detect any of the traffic lights
+        
     
     #
     # Utility funcs

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -77,9 +77,9 @@ class TLDetector(object):
         """
         self.has_image = True
         self.camera_image = msg
-        rospy.logwarn('Enter image_cb function!')
+        
         light_wp, state = self.process_traffic_lights()
-        rospy.logwarn('light_wp: %s state: %s ', light_wp, state)
+        
         '''
         Publish upcoming red lights at camera frequency.
         Each predicted state has to occur `STATE_COUNT_THRESHOLD` number
@@ -163,16 +163,21 @@ class TLDetector(object):
                     diff = d
                     closest_light = light
                     line_wp_idx = temp_wp_idx
-        rospy.logwarn('red: %s, yellow: %s,  green: %s, unknown: %s', TrafficLight.RED, TrafficLight.YELLOW, TrafficLight.GREEN, TrafficLight.UNKNOWN)
-        if closest_light:
+            
+            # if the distance between current vehicle position and the closest traffic light position is larger than 250 waypoints, then return 'Unknown' State
+            
+        if closest_light and diff < 250:
             state = self.get_light_state(closest_light)
-            rospy.logwarn('Recognized state: %s, Diff: %s,  Light state: %s', 
-              state, diff, closest_light)
+            classes = {TrafficLight.RED : 'Red',
+                        TrafficLight.YELLOW : 'Yellow',
+                        TrafficLight.GREEN : 'Green',
+                        TrafficLight.UNKNOWN : 'Unknown'}
+            rospy.logwarn('\n Recognized Traffic Light: %s \n Distance between the closest traffic light and current vehicle: %s \n\n', 
+              classes[state], diff)
+            
             return line_wp_idx, state
         
-#         self.waypoints = None
-        rospy.logwarn('No closest light. Diff: %s, Light state: %s', 
-               diff, closest_light)
+        rospy.logwarn('TrafficLight is too far. No traffic light detected.')
         return -1, TrafficLight.UNKNOWN
 
 if __name__ == '__main__':


### PR DESCRIPTION
Updated rospy.logwarn and disabled image classification if necessary by adding `diff < 250`:

```
# if the distance between current vehicle position and the closest traffic light position is larger than 250 waypoints, then return 'Unknown' State
            
        if closest_light and diff < 250:
            state = self.get_light_state(closest_light)
            classes = {TrafficLight.RED : 'Red',
                        TrafficLight.YELLOW : 'Yellow',
                        TrafficLight.GREEN : 'Green',
                        TrafficLight.UNKNOWN : 'Unknown'}
            rospy.logwarn('\n Recognized Traffic Light: %s \n Distance between the closest traffic light and current vehicle: %s \n\n', 
              classes[state], diff)
            
            return line_wp_idx, state
        
        rospy.logwarn('TrafficLight is too far. No traffic light detected.')
        return -1, TrafficLight.UNKNOWN
```